### PR TITLE
Fix compilation error in poll_driver.c

### DIFF
--- a/Linux/Device_Driver/Poll/poll_driver.c
+++ b/Linux/Device_Driver/Poll/poll_driver.c
@@ -215,7 +215,7 @@ static int __init etx_driver_init(void)
   }
         
   /*Creating device*/
-  if(IS_ERR(device_create(dev_class,NULL,dev,NULL,"etx_device"))){
+  if(IS_ERR(device_create(dev_class,NULL,dev,NULL,"etx_device")))
   {
     pr_err("Cannot create the Device 1\n");
     goto r_device;


### PR DESCRIPTION
The extra '{' makes this file uncompilable and this CL fixes that.